### PR TITLE
Hash hotfix

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -106,17 +106,18 @@ class Debugger
         // For example if dustpress()->render() will be called multiple times 'dustpress/data' will run multiple times.
         // The hash cannot change so we need to check if the value has been set already.
         if ( empty( self::$hash ) ) {
+
             self::$hash = md5( $_SERVER['REQUEST_URI'] . microtime() );
+
+            $data_array = array(
+                'ajaxurl' => admin_url('admin-ajax.php'),
+                'hash'    => self::$hash
+            );
+
+            wp_localize_script( 'dustpress_debugger', 'dustpress_debugger', $data_array );
+
+            wp_enqueue_script( 'dustpress_debugger' );
         }
-
-        $data_array = array(
-            'ajaxurl' => admin_url('admin-ajax.php'),
-            'hash'    => self::$hash
-        );
-
-        wp_localize_script( 'dustpress_debugger', 'dustpress_debugger', $data_array );
-
-        wp_enqueue_script( 'dustpress_debugger' );
 
         return $data;
     }

--- a/plugin.php
+++ b/plugin.php
@@ -99,21 +99,24 @@ class Debugger
     /**
      * Sets the hash for the data to the DOM to get.
      * @param object $data DustPress render data
+     * @return object
      */
+    public static function set_hash( $data ) {
 
-    public static function set_hash($data)
-    {
-        // Unique hash
-        self::$hash = md5($_SERVER['REQUEST_URI'] . microtime());
+        // For example if dustpress()->render() will be called multiple times 'dustpress/data' will run multiple times.
+        // The hash cannot change so we need to check if the value has been set already.
+        if ( empty( self::$hash ) ) {
+            self::$hash = md5( $_SERVER['REQUEST_URI'] . microtime() );
+        }
 
         $data_array = array(
-            'ajaxurl'   => admin_url('admin-ajax.php'),
-            'hash'      => self::$hash
+            'ajaxurl' => admin_url('admin-ajax.php'),
+            'hash'    => self::$hash
         );
 
-        wp_localize_script('dustpress_debugger', 'dustpress_debugger', $data_array);
+        wp_localize_script( 'dustpress_debugger', 'dustpress_debugger', $data_array );
 
-        wp_enqueue_script('dustpress_debugger');
+        wp_enqueue_script( 'dustpress_debugger' );
 
         return $data;
     }

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Plugin Name: DustPress Debugger
  * Plugin URI: https://github.com/devgeniem/dustpress-debugger
  * Description: Provides handy ajaxified debugger tool for DustPress based themes.
- * Version: 1.7.0
+ * Version: 1.7.1
  * Author: Geniem Oy / Miika Arponen & Ville Siltala
  * Author URI: http://www.geniem.com
  */


### PR DESCRIPTION
If `dustpress()->render()` will be called the 'dustpress/data' will run multiple times.
This causes the problem that set_hash() will be called multiple times and the ajax request hash will be changed.
Added a check for the self::$hash.